### PR TITLE
Forcing BLE mode for pairing, gatttool commands

### DIFF
--- a/Bluetooth/Platforms/RaspberryPi.md
+++ b/Bluetooth/Platforms/RaspberryPi.md
@@ -6,6 +6,22 @@ GoPro needs to be paired at least with one device to turn the wireless (includin
 
 Following procedure was tested on Raspberry Pi Zero W with Raspbian Stretch (release 2018-04-18) and GoPro HERO5 with FW 2.60.
 
+If you're using BlueZ 5.50 or later, you might need to force the controller to run only in BLE mode with this line in /etc/bluetooth/main.conf (the comments are already there - this is to help you locate the commented statement):
+```
+# Restricts all controllers to the specified transport. Default value
+# is "dual", i.e. both BR/EDR and LE enabled (when supported by the HW).
+# Possible values: "dual", "bredr", "le"
+ControllerMode = le
+```
+If this still doesn't allow the pairing to complete, try disabling the SAP plugin by modifying /lib/systemd/system/bluetooth.service:
+```
+ExecStart=/usr/lib/bluetooth/bluetoothd --noplugin=sap
+```
+And restart the Bluetooth daemon:
+```shell
+systemctl daemon-reload
+systemctl restart bluetooth.service
+```
 ## How to
 
 First step is to prepare Raspberry. If you already have Raspbian set up, you can skip to the next section
@@ -85,6 +101,7 @@ Now it's time to connect Raspberry to GoPro.
     [CHG] Device DE:71:28:EE:A7:FD Paired: yes
     Pairing successful
     ```
+Make sure the negotiated pairing keys are stored in /var/lib/bluetooth/${HCI_MAC}/${GOPRO_MAC}/info - there should be 4 sections titled: RemoteSignatureKey, LocalSignatureKey, LongTermKey, SlaveLongTermKey. Without these, you technically didn't complete pairing and you would not be able to access the GoPro over BLE until you reset all connections on the GoPro to start the pairing process again.
 
 Now GoPro is paired with Raspberry. Now you can try to wake up your GoPro over Bluetooth.
 
@@ -157,6 +174,10 @@ But probably what you want the most is ability to turn on the WiFi over Bluetoot
     to turn the WiFi off.
 
 ------
+Step 13-15 can be run on directly on the command line, and you can substitute the different value below to replicate step 16 and 17 :
+```shell
+sudo gatttool -t random -b DE:71:28:EE:A7:FD --char-write-req -a 0x2f -n 03160101
+```
 
 This is just a first try to control GoPro over the WiFi. In case you want to elaborate more, take a look at [this article](https://gethypoxic.com/blogs/technical/gopro-hero5-interfaces) from HYPOXIC (especially the Bluetooth section). And you can [learn more about the `gatttool`](https://github.com/pcborenstein/bluezDoc/wiki/hcitool-and-gatttool-example).
 


### PR DESCRIPTION
For BlueZ 5.50 that came with Raspbian Buster, you will likely need to force the Bluetooth Controller to running only in LE mode in order for the pairing to succeed. Also added non-interactive gatttool commands

* GoPro Camera(s): GoPro Hero 5/6/7/8
* Tested on: GoPro Hero 5 Black
* Firmware version: 2.60
